### PR TITLE
Fixed compiling on Windows

### DIFF
--- a/src/System/IO/WindowsCompat.hs
+++ b/src/System/IO/WindowsCompat.hs
@@ -125,7 +125,11 @@ getFileStatus fp =
        isdir <- doesDirectoryExist fp
        perms <- getPermissions fp
        modct <- getModificationTime fp
+#if MIN_VERSION_directory(1,2,0)
        let epochtime = utcTimeToSeconds modct
+#else
+       let epochtime = clockTimeToEpoch modct
+#endif
        return $ FileStatusCompat {deviceID = -1,
                                   fileID = -1,
                                   fileMode = if isfile then regularFileMode


### PR DESCRIPTION
`getModificationTime` returns UTCTime instead of ClockTime
