### PR TITLE
add takeR(:: Int -> Seq a -> Seq a) and dropR(:: Int -> Seq a -> Seq a)

### DIFF
--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -46,6 +46,7 @@ Library
  Hs-Source-Dirs: src
  Exposed-Modules:
   Data.String.Utils, System.IO.Utils, System.IO.Binary, Data.List.Utils,
+  Data.Sequence.Utils,
   System.Daemon,
   Text.ParserCombinators.Parsec.Utils,
   Network.Email.Mailbox,
@@ -133,7 +134,8 @@ test-suite runtests
     Strtest,
     Tests,
     Timetest,
-    WildMatchtest
+    WildMatchtest,
+    Sequencetest
   Extensions: ExistentialQuantification, OverlappingInstances,
     UndecidableInstances, CPP, Rank2Types,
     MultiParamTypeClasses, FlexibleInstances, FlexibleContexts,

--- a/src/Data/Sequence/Utils.hs
+++ b/src/Data/Sequence/Utils.hs
@@ -1,0 +1,22 @@
+module Data.Sequence.Utils (takeR, dropR) where
+
+import Data.Sequence (Seq)
+import qualified Data.Sequence as S
+
+{- | /O(log(min(i,n-1)))/. The last @i@ elements of a sequence.
+     If @i@ is negative, @'takeR' i s@ yields the empty sequence.
+     If the sequence contains fewer than @i@ elements, the whole
+     sequence is returned.
+
+     @'takeR' i@ is equivalent to @'reverse' . ('take' i) . 'reverse'@. -}
+takeR     :: Int -> Seq a -> Seq a
+takeR i s =  S.drop (subtract i $ S.length s) s
+
+{- | /O(log(min(i,n-1)))/. Elements of a sequence before the last @i@.
+     If @i@ is negative, @'dropR' i s@ yields the whole sequence.
+     If the sequence contains fewer than @i@ elements, the empty
+     sequence is returned.
+
+     @'dropR' i@ is equivalent to @'reverse' . ('drop' i) . 'reverse'@. -}
+dropR     :: Int -> Seq a -> Seq a
+dropR i s = S.take (subtract i $ S.length s) s

--- a/testsrc/Sequencetest.hs
+++ b/testsrc/Sequencetest.hs
@@ -1,0 +1,17 @@
+module Sequencetest(tests) where
+import Data.Sequence (Seq)
+import qualified Data.Sequence.Utils as S
+import qualified Data.Sequence as S
+import Test.HUnit
+import Test.HUnit.Tools
+
+prop_takeR n l =
+  (S.reverse . S.take n . S.reverse $ s) == (S.takeR n s) where
+    s = S.fromList l :: Seq Bool
+
+prop_dropR n l =
+  (S.reverse . S.drop n . S.reverse $ s) == (S.dropR n s) where
+    s = S.fromList l :: Seq Bool
+
+tests = TestList [qctest "takeR" prop_takeR,
+                  qctest "dropR" prop_dropR]

--- a/testsrc/Tests.hs
+++ b/testsrc/Tests.hs
@@ -26,6 +26,7 @@ import qualified Str.CSVtest
 import qualified WildMatchtest
 import qualified Globtest
 import qualified ProgressTrackertest
+import qualified Sequencetest
 
 test1 = TestCase ("x" @=? "x")
 
@@ -46,6 +47,5 @@ tests = TestList [TestLabel "test1" test1,
                  TestLabel "Eithertest" Eithertest.tests,
                  TestLabel "CRC32POSIXtest" CRC32POSIXtest.tests,
                  TestLabel "CRC32GZIPtest" CRC32GZIPtest.tests,
-                 TestLabel "GZiptest" GZiptest.tests]
-
-
+                 TestLabel "GZiptest" GZiptest.tests,
+                 TestLabel "Sequence" Sequencetest.tests]


### PR DESCRIPTION
Data.Sequence has both `takeWhileR` and `dropWhileR` but no `takeR` or `dropR`.
