### PR TITLE
Adds support for unix-2.7.0 (included in GHC 7.8)

### DIFF
--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -1,5 +1,5 @@
 Name: MissingH
-Version: 1.2.0.2
+Version: 1.2.0.3
 License: BSD3
 Maintainer: John Goerzen <jgoerzen@complete.org>
 Author: John Goerzen


### PR DESCRIPTION
The `Terminated` constructor of `ProcessStatus` in unix-2.7.0.0 includes a second argument of type `Bool`  which indicates whether or not a coredump was created.
This patch adds support for that flag via the use of MIN_VERSION_unix macros.
