### PR TITLE
Use sortOn in packLargeFirst

### DIFF
--- a/src/Data/BinPacking.hs
+++ b/src/Data/BinPacking.hs
@@ -100,8 +100,7 @@ and keep packing the largest object from the remainder until no object can
 be found to put in the bin.  This is substantially more efficient than
 'packByOrder', but requires sorting the input. -}
 packLargeFirst :: BinPacker
-packLargeFirst bins sizes = packLargeFirst' bins (sortBy fstSort sizes)
-    where fstSort a b = compare (fst a) (fst b)
+packLargeFirst bins sizes = packLargeFirst' bins (sortOn fst sizes)
 
 packLargeFirst' :: BinPacker
 packLargeFirst' _ [] = Right []                     -- Ran out of sizes


### PR DESCRIPTION
Just a slight simplification.  From [the docs](https://hackage.haskell.org/package/base-4.10.1.0/docs/Data-List.html#v:sortOn):

> [`sortOn`] has the performance advantage of only evaluating [the key function] once for each element in the input list