### PR TITLE
Bump bounds for base for ghc 8.8

### DIFF
--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -112,7 +112,7 @@ library
 
   build-depends:
       array               >= 0.4.0.0 && < 0.6
-    , base                >= 4.5.0.0 && < 4.13
+    , base                >= 4.5.0.0 && < 4.14
     , containers          >= 0.4.2.1 && < 0.7
     , directory           >= 1.1.0.2 && < 1.4
     , filepath            >= 1.3.0.0 && < 1.5


### PR DESCRIPTION
This change makes `MissingH` build with ghc 8.8. If accepted, could we have an hackage release too?