### PR TITLE
Bump to 1.6.0.0, allow directory-1.3.8 and unix-2.8, disabling Safe for some modules

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.202211107
+# version: 0.15.20221225
 #
-# REGENDATA ("0.15.202211107",["github","MissingH.cabal"])
+# REGENDATA ("0.15.20221225",["github","MissingH.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,9 +34,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.3
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.4.3
+            compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.5
@@ -186,7 +186,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -222,7 +222,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ _Andreas Abel, 2023-01-14_
   * `System.Path`
   * `System.Path.Glob`
   * `System.Path.NameManip`
+- Allow `unix-2.8.0.0` (enables `directory-1.3.8.0`).
+- Tested with GHC 7.10 - 9.6 alpha1.
 
 ### 1.5.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+# 1.6.0.0
+
+_Andreas Abel, 2023-01-14_
+
+- Allow `directory-1.3.8.0` which is no longer `Safe` Haskell.
+  Thus, we need to revoke `Safe` status of the following modules:
+  * `Data.MIME.Types`
+  * `Network.Email.Sendmail`
+  * `System.IO.HVFS`
+  * `System.IO.HVFS.Combinators`
+  * `System.IO.HVFS.InstanceHelpers`
+  * `System.Path`
+  * `System.Path.Glob`
+  * `System.Path.NameManip`
+
 ### 1.5.0.1
 
 _Andreas Abel, 2022-03-14_

--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -1,7 +1,6 @@
 cabal-version: 1.12
 name: MissingH
-version: 1.5.0.1
-x-revision: 2
+version: 1.6.0.0
 
 build-type: Simple
 license: BSD3
@@ -126,9 +125,7 @@ library
       array               >= 0.4.0.0 && < 0.6
     , base                >= 4.8.0.0 && < 5
     , containers          >= 0.4.2.1 && < 0.7
-    , directory           >= 1.1.0.2 && < 1.3.8
-        -- build failure with 1.3.8.0 (System.Directory is no longer safe)
-        -- see https://github.com/haskell/directory/issues/147
+    , directory           >= 1.1.0.2 && < 1.4
     , filepath            >= 1.3.0.0 && < 1.5
     , hslogger            >= 1.3.0.0 && < 1.4
     , mtl                 >= 1.1.1.0 && < 2.4

--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -10,7 +10,7 @@ maintainer: Andreas Abel
 license-file: LICENSE
 
 tested-with:
-  GHC == 9.4.3
+  GHC == 9.4.4
   GHC == 9.2.5
   GHC == 9.0.2
   GHC == 8.10.7

--- a/MissingH.cabal
+++ b/MissingH.cabal
@@ -143,7 +143,7 @@ library
     build-depends: network >= 2.6.3.1 && <2.9
 
   If !os(windows)
-    Build-Depends: unix   >= 2.5.1.0 && < 2.8
+    Build-Depends: unix   >= 2.5.1.0 && < 2.9
 
   ghc-options:     -Wall
   if impl(ghc >= 8)

--- a/src/Data/MIME/Types.hs
+++ b/src/Data/MIME/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE Safe #-}
-
 {- arch-tag: MIME Types main file
 Copyright (c) 2004-2011 John Goerzen <jgoerzen@complete.org>
 
@@ -37,14 +35,14 @@ where
 
 import qualified Data.Map as Map
 import qualified Control.Exception (try, IOException)
-import safe Control.Monad ( foldM )
-import safe System.IO
+import Control.Monad ( foldM )
+import System.IO
     ( Handle, hClose, openFile, IOMode(ReadMode) )
-import safe System.IO.Error ()
-import safe System.IO.Utils ( hGetLines )
-import safe System.Path ( splitExt )
-import safe Data.Map.Utils ( flippedLookupM )
-import safe Data.Char ( toLower )
+import System.IO.Error ()
+import System.IO.Utils ( hGetLines )
+import System.Path ( splitExt )
+import Data.Map.Utils ( flippedLookupM )
+import Data.Char ( toLower )
 
 ----------------------------------------------------------------------
 -- Basic type declarations

--- a/src/Network/Email/Sendmail.hs
+++ b/src/Network/Email/Sendmail.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE Safe #-}
 
 {- arch-tag: Sendmail utility
 Copyright (c) 2004-2011 John Goerzen <jgoerzen@complete.org>
@@ -31,11 +30,11 @@ where
 module Network.Email.Sendmail(sendmail)
 where
 
-import safe System.Cmd.Utils ( PipeMode(WriteToPipe), pOpen )
-import safe System.Directory
+import System.Cmd.Utils ( PipeMode(WriteToPipe), pOpen )
+import System.Directory
     ( doesFileExist, getPermissions, Permissions(executable) )
-import safe System.IO ( hPutStr )
-import safe System.IO.Error ()
+import System.IO ( hPutStr )
+import System.IO.Error ()
 import qualified Control.Exception(try, IOException)
 
 sendmails :: [String]

--- a/src/System/Daemon.hs
+++ b/src/System/Daemon.hs
@@ -86,7 +86,13 @@ child2 :: IO ()
 child2 = trap $
     do setCurrentDirectory "/"
        mapM_ closeFd [stdInput, stdOutput, stdError]
-       nullFd <- openFd "/dev/null" ReadWrite Nothing defaultFileFlags
+       nullFd <- openFd
+         "/dev/null"
+         ReadWrite
+#if !MIN_VERSION_unix(2,8,0)
+         Nothing
+#endif
+         defaultFileFlags
        mapM_ (dupTo nullFd) [stdInput, stdOutput, stdError]
        closeFd nullFd
 #endif

--- a/src/System/IO/HVFS.hs
+++ b/src/System/IO/HVFS.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                  #-}
-{-# LANGUAGE Safe                 #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {- arch-tag: HVFS main file
 Copyright (c) 2004-2011 John Goerzen <jgoerzen@complete.org>

--- a/src/System/IO/HVFS/Combinators.hs
+++ b/src/System/IO/HVFS/Combinators.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE Safe #-}
 {- arch-tag: HVFS Combinators
 Copyright (c) 2004-2011 John Goerzen <jgoerzen@complete.org>
 
@@ -26,10 +25,10 @@ module System.IO.HVFS.Combinators ( -- * Restrictions
                                     HVFSChroot, newHVFSChroot)
     where
 
-import safe System.IO ( IOMode(ReadMode) )
-import safe System.IO.Error
+import System.IO ( IOMode(ReadMode) )
+import System.IO.Error
     ( doesNotExistErrorType, permissionErrorType )
-import safe System.IO.HVFS
+import System.IO.HVFS
     ( HVFSOpenable(vOpen),
       HVFS(vRemoveFile, vCreateLink, vCreateSymbolicLink, vRenameFile,
            vRenameDirectory, vRemoveDirectory, vCreateDirectory,

--- a/src/System/IO/HVFS/InstanceHelpers.hs
+++ b/src/System/IO/HVFS/InstanceHelpers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {- arch-tag: HVFS instance helpers
@@ -38,11 +37,11 @@ module System.IO.HVFS.InstanceHelpers(-- * HVFSStat objects
 import           Data.IORef            (IORef, newIORef, readIORef, writeIORef)
 import           Data.List             (genericLength)
 import           System.FilePath       (isPathSeparator, pathSeparator, (</>))
-import safe System.IO ( IOMode(ReadMode) )
+import           System.IO             ( IOMode(ReadMode) )
 import           System.IO.Error       (doesNotExistErrorType,
                                         illegalOperationErrorType,
                                         permissionErrorType)
-import safe System.IO.HVFS
+import System.IO.HVFS
     ( FileOffset,
       HVFSOpenable(vOpen),
       HVFS(vGetDirectoryContents, vGetFileStatus, vSetCurrentDirectory,

--- a/src/System/Path.hs
+++ b/src/System/Path.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE Safe #-}
 {- arch-tag: Path utilities main file
 Copyright (C) 2004-2011 John Goerzen <jgoerzen@complete.org>
 
@@ -31,22 +30,22 @@ module System.Path(-- * Name processing
                      mktmpdir, brackettmpdir, brackettmpdirCWD
                     )
 where
-import safe Data.List.Utils ( startswith, alwaysElemRIndex )
+import Data.List.Utils ( startswith, alwaysElemRIndex )
 #if !(defined(mingw32_HOST_OS) || defined(mingw32_TARGET_OS) || defined(__MINGW32__))
-import safe System.Directory
+import System.Directory
     ( getCurrentDirectory, removeFile, setCurrentDirectory )
-import safe System.Posix.Directory ( createDirectory )
-import safe System.Posix.Temp ( mkstemp )
+import System.Posix.Directory ( createDirectory )
+import System.Posix.Temp ( mkstemp )
 #else
-import safe System.Directory
-import safe System.IO ( openTempFile )
+import System.Directory
+import System.IO ( openTempFile )
 #endif
-import safe Control.Exception ( finally )
-import safe System.FilePath ( pathSeparator )
-import safe System.IO ( hClose )
-import safe System.IO.HVFS.Utils
+import Control.Exception ( finally )
+import System.FilePath ( pathSeparator )
+import System.IO ( hClose )
+import System.IO.HVFS.Utils
     ( SystemFS(SystemFS), recurseDir, recurseDirStat, recursiveRemove )
-import safe System.Path.NameManip
+import System.Path.NameManip
     ( normalise_path, absolute_path_by, guess_dotdot )
 
 {- | Splits a pathname into a tuple representing the root of the name and

--- a/src/System/Path/Glob.hs
+++ b/src/System/Path/Glob.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE Safe #-}
-
 {-
 Copyright (c) 2006-2011 John Goerzen <jgoerzen@complete.org>
 
@@ -30,7 +28,7 @@ import           Control.Exception     (tryJust)
 import           Data.List             (isSuffixOf)
 import           Data.List.Utils       (hasAny)
 import           System.FilePath       (pathSeparator, splitFileName, (</>))
-import safe      System.IO.HVFS        (HVFS (vDoesDirectoryExist, vDoesExist, vGetDirectoryContents),
+import           System.IO.HVFS        (HVFS (vDoesDirectoryExist, vDoesExist, vGetDirectoryContents),
                                          SystemFS (SystemFS))
 import           System.Path.WildMatch (wildCheckCase)
 

--- a/src/System/Path/NameManip.hs
+++ b/src/System/Path/NameManip.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {- |


### PR DESCRIPTION
Because `directory-1.3.8.0` is no longer `Safe`, we need to abandon the Safe Haskell for modules importing `System.Directory`.

Refs:
- https://github.com/haskell/directory/issues/147
- fix #62
